### PR TITLE
Update Livereload/Instant Refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To enable Livereload and Instant Refresh during development (when running `npm r
 ```json
 {
   "server": {
-    "url": "192.168.1.2:3000"
+    "url": "http://192.168.1.2:3000"
   }
 }
 ```


### PR DESCRIPTION
The capacitor config to make it point to a local network address must start with `http://`